### PR TITLE
Fix exception when mulitple folder levels have to be created

### DIFF
--- a/anonymizer/anonymization/anonymizer.py
+++ b/anonymizer/anonymization/anonymizer.py
@@ -59,7 +59,7 @@ class Anonymizer:
         for input_image_path in tqdm(files):
             # Create output directory
             relative_path = input_image_path.relative_to(input_path)
-            (Path(output_path) / relative_path.parent).mkdir(exist_ok=True)
+            (Path(output_path) / relative_path.parent).mkdir(exist_ok=True, parents=True)
             output_image_path = Path(output_path) / relative_path
             output_detections_path = (Path(output_path) / relative_path).with_suffix('.json')
 


### PR DESCRIPTION
When anonymizing a folder structure such as:
a/b/c/1.png
a/b/c/2.png
a/b/d/1.png
into a folder a_anon so that the resulting structure looks like this:
a_anon/b/c/1.png
a_anon/b/c/2.png
a_anon/b/d/1.png
an exception about the folder a_anon/b/c not existing is thrown. This simple fix makes sure that all parent directories are created if necessary.